### PR TITLE
Keep handles outside bubbles, not just their content region

### DIFF
--- a/src/curveTail.ts
+++ b/src/curveTail.ts
@@ -20,7 +20,7 @@ export class CurveTail extends Tail {
             newPosition = Bubble.defaultMid(this.currentStartPoint(), this.tip);
         }
         if (this.bubble) {
-            newPosition = Comical.movePointOutsideBubbleContent(this.bubble.content, newPosition);
+            newPosition = Comical.movePointOutsideBubble(this.bubble.content, newPosition, this.tip);
         }
         this.mid = newPosition;
         if (this.midHandle) {
@@ -57,10 +57,7 @@ export class CurveTail extends Tail {
             }
             if (this.bubble) {
                 const [parentElement] = Comical.comicalParentOf(this.bubble.content);
-                if (
-                    parentElement &&
-                    Comical.bubbleWithContentAtPoint(parentElement, event.point!.x!, event.point!.y!)
-                ) {
+                if (parentElement && Comical.getBubbleHit(parentElement, event.point!.x!, event.point!.y!)) {
                     return; // refuse to drag mid to a point inside a bubble
                 }
             }


### PR DESCRIPTION
Includes a complete rewrite of the algorithm for moving a handle outside a bubble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/comical-js/40)
<!-- Reviewable:end -->
