### PR TITLE
Make thought bubble arcs shallower and more varied

### DIFF
--- a/src/bubble.ts
+++ b/src/bubble.ts
@@ -483,7 +483,10 @@ export class Bubble {
             this.shadowShape.fillColor = this.shadowShape.strokeColor;
         }
 
-        this.contentHolder.strokeWidth = 0;
+        // If we don't do this it somehow shows up in the fill area clone,
+        // on top of the outline if it dips inside the rectangle
+        this.contentHolder.remove();
+
         this.fillArea = this.outline.clone({ insert: false });
         Comical.setItemOnClick(this.fillArea, () => {
             Comical.activateBubble(this);
@@ -1017,7 +1020,7 @@ export class Bubble {
 
         let remainingLength = outlineShape.length;
         const delta = remainingLength / arcCount;
-        const maxJitter = delta / 5;
+        const maxJitter = delta / 2;
         for (let i = 0; i < arcCount; i++) {
             const expectedPlace = i * delta;
             // This introduces a bit of randomness to make it look more natural.

--- a/src/thoughtBubble.ts
+++ b/src/thoughtBubble.ts
@@ -9,7 +9,7 @@ import { SimpleRandom } from "./random";
 // However, I'm not sure things will stay that way, so I'm leaving the
 // duplication for now. It's a fairly small chunk of code.
 export function makeThoughtBubble(bubble: Bubble): Item {
-    const arcDepth = 15;
+    const arcDepth = 9;
     // Seed the random number generator with a value predictable enough
     // that it will look the same each time the page is opened...
     // in fact it will go back to the same shape if the bubble grows
@@ -20,7 +20,7 @@ export function makeThoughtBubble(bubble: Bubble): Item {
 
     return bubble.makeBubbleItem(0, (points, center) => {
         const outline = new Path();
-        const maxJitter = arcDepth / 4;
+        const maxJitter = arcDepth / 2;
         for (let i = 0; i < points.length; i++) {
             const start = points[i];
             const end = i < points.length - 1 ? points[i + 1] : points[0];


### PR DESCRIPTION
...in both depth and length. (Also makes pointedArc/exclamation more varied in length.)
... and a small fix to prevent content holder rectangle overlaying outline

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/comical-js/48)
<!-- Reviewable:end -->
