### PR TITLE
Allow client to set handle colors

### DIFF
--- a/src/comical.ts
+++ b/src/comical.ts
@@ -38,6 +38,8 @@ export class Comical {
 
     static activeBubbleListener: ((active: HTMLElement | undefined) => void) | undefined;
 
+    // This is something the client calls only once when setting up comical. After that,
+    // there is no attempt to update anything already showing on screen.
     public static setUserInterfaceProperties(props: IUserInterfaceProperties) {
         Comical.tailHandleColor = new Color(props.tailHandleColor);
     }

--- a/src/comical.ts
+++ b/src/comical.ts
@@ -21,14 +21,26 @@ import { ContainerData } from "./containerData";
 // Finally, Comical can replace a finished bubble canvas with a single SVG, resulting in
 // a visually identical set of bubbles that can be rendered without using Canvas and
 // Javascript.
+
+interface IUserInterfaceProperties {
+    tailHandleColor: string;
+}
+
 export class Comical {
     static backColor = new Color("white");
+
+    //client can change this using setUserInterfaceProperties
+    public static tailHandleColor = new Color("orange");
 
     static activeContainers = new Map<Element, ContainerData>();
 
     static activeBubble: Bubble | undefined;
 
     static activeBubbleListener: ((active: HTMLElement | undefined) => void) | undefined;
+
+    public static setUserInterfaceProperties(props: IUserInterfaceProperties) {
+        Comical.tailHandleColor = new Color(props.tailHandleColor);
+    }
 
     public static startEditing(parents: HTMLElement[]): void {
         parents.forEach(parent => Comical.convertBubbleJsonToCanvas(parent));

--- a/src/handle.ts
+++ b/src/handle.ts
@@ -1,35 +1,41 @@
-import { Point, Path, Color, Layer } from "paper";
+import { Point, Path, Layer } from "paper";
 import { activateLayer } from "./utilities";
 import { Tail } from "./tail";
+import { Comical } from "./comical";
 
 // This class represents one of the handles used to manipulate tails.
 export class Handle {
-    // Enhance/refactor: with a few more functions, we could make this private.
-    handle: Path.Circle;
+    private circle: Path.Circle;
 
     // Helps determine unique names for the handles
     static handleIndex = 0;
 
-    constructor(layer: Layer, position: Point, solid: boolean) {
+    constructor(layer: Layer, position: Point, autoMode: boolean) {
         activateLayer(layer);
-        const result = new Path.Circle(position, 5);
-        result.strokeColor = new Color("#1d94a4");
-        result.fillColor = new Color("#1d94a4"); // a distinct instance of Color, may get made transparent below
-        result.strokeWidth = 1;
-        if (!solid) {
-            Tail.makeTransparentClickable(result);
-        }
-        result.name = "handle" + Handle.handleIndex++;
-        result.visible = true;
-        result.data = this;
-        this.handle = result;
+        this.circle = new Path.Circle(position, 5);
+        this.circle.strokeColor = Comical.tailHandleColor;
+        this.circle.strokeWidth = 1;
+        this.circle.name = "handle" + Handle.handleIndex++;
+        this.circle.visible = true;
+        this.circle.data = this;
+        this.setAutoMode(autoMode);
+    }
+
+    setAutoMode(autoMode: boolean) {
+        this.circle.fillColor = autoMode ? Tail.transparentColor : Comical.tailHandleColor;
     }
 
     getPosition(): Point {
-        return this.handle.position!;
+        return this.circle.position!;
     }
     setPosition(p: Point) {
-        this.handle.position = p;
+        this.circle.position = p;
+    }
+    setVisibility(visibility: boolean) {
+        this.circle.visible = visibility;
+    }
+    bringToFront() {
+        this.circle.bringToFront();
     }
 
     onDrag: (p: Point) => void;

--- a/src/tail.ts
+++ b/src/tail.ts
@@ -1,4 +1,4 @@
-import { Path, Point, Color, Layer, Item } from "paper";
+import { Path, Point, Color, Layer } from "paper";
 import { Comical } from "./comical";
 import { TailSpec } from "bubbleSpec";
 import { Bubble } from "./bubble";
@@ -168,9 +168,7 @@ export class Tail {
         let tipHandle: Handle;
 
         if (!this.spec.joiner) {
-            // usual case...we want a handle for the tip.
-            const isHandleSolid = false;
-            tipHandle = new Handle(this.handleLayer, this.tip, isHandleSolid);
+            tipHandle = new Handle(this.handleLayer, this.tip, true /* auto mode*/);
 
             tipHandle.onDrag = (where: Point) => {
                 if (!this.okToMoveHandleTo(where)) {
@@ -221,10 +219,5 @@ export class Tail {
     // you can see where the tip actually ends up. But if it's perfectly transparent,
     // paper.js doesn't register hit tests on the transparent part. So go for a very
     // small alpha.
-    static makeTransparentClickable(item: Item) {
-        if (!item.fillColor) {
-            item.fillColor = new Color("#1d94a4");
-        }
-        item.fillColor.alpha = 0.01;
-    }
+    public static transparentColor: Color = new Color("#FFFFFF11");
 }

--- a/stories/index.stories.ts
+++ b/stories/index.stories.ts
@@ -1123,6 +1123,7 @@ storiesOf("comical", module)
         return wrapDiv;
     })
     .add("compare with real bubbles", () => {
+        Comical.setUserInterfaceProperties({ tailHandleColor: "pink" });
         const wrapDiv = document.createElement("div");
         wrapDiv.style.position = "relative";
         const firstPicDiv = document.createElement("div");


### PR DESCRIPTION
* Allow client to set handle colors
*  Hide and encapsulate the circle of the handle so that Curved Tail isn't messing with Handle internals
* Hide the implementation of auto-mode on/off from users of Handle
* Just re-use the same two colors instead of creating new ones

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/comical-js/49)
<!-- Reviewable:end -->
