### PR TITLE
Keep child bubble tail midpoint handle between bubbles (BL-7924)

### DIFF
--- a/src/curveTail.ts
+++ b/src/curveTail.ts
@@ -1,5 +1,5 @@
 import { Tail } from "./tail";
-import { Point } from "paper";
+import { Point, Size } from "paper";
 import { Comical } from "./comical";
 import { Bubble } from "./bubble";
 import { Handle } from "./handle";
@@ -18,15 +18,16 @@ export class CurveTail extends Tail {
     adjustForChangedRoot(delta: Point): void {
         let newPosition = this.mid.add(delta.divide(2));
         if (this.bubble && this.spec.autoCurve) {
+            const parent = Comical.findParent(this.bubble);
             newPosition = Bubble.defaultMid(
                 this.currentStartPoint(),
                 this.tip,
-                this.bubble.content.offsetWidth,
-                this.bubble.content.offsetHeight
+                new Size(this.bubble.content.offsetWidth, this.bubble.content.offsetHeight),
+                parent ? new Size(parent.content.offsetWidth, parent.content.offsetHeight) : undefined
             );
         }
         if (this.bubble) {
-            newPosition = Comical.movePointOutsideBubble(this.bubble.content, newPosition, this.tip);
+            newPosition = Comical.movePointOutsideBubble(this.bubble.content, newPosition, this.tip, this.root);
         }
         this.mid = newPosition;
         if (this.midHandle) {

--- a/stories/index.stories.ts
+++ b/stories/index.stories.ts
@@ -12,7 +12,8 @@ import {
     Shape,
     Segment,
     Path,
-    ToolEvent
+    ToolEvent,
+    Size
 } from "paper";
 import { Comical } from "../src/comical";
 import { Bubble } from "../src/bubble";
@@ -239,7 +240,7 @@ storiesOf("comical", module)
         const handleLayer = new Layer();
         project!.addLayer(layer2);
         project!.addLayer(handleLayer);
-        const mid = Bubble.defaultMid(start, tip);
+        const mid = Bubble.defaultMid(start, tip, new Size(0, 0));
         const tail = new ArcTail(
             start,
             tip,
@@ -1241,7 +1242,7 @@ storiesOf("comical", module)
         const handleLayer = new Layer();
         project!.addLayer(layer2);
         project!.addLayer(handleLayer);
-        const mid = Bubble.defaultMid(start, tip);
+        const mid = Bubble.defaultMid(start, tip, new Size(0, 0));
 
         const tail = new LineTail(
             start,


### PR DESCRIPTION
Also, child bubble tail now defaults to autoCurve:true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bloombooks/comical-js/53)
<!-- Reviewable:end -->
